### PR TITLE
Remove non-essential opcodes hooking

### DIFF
--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -173,14 +173,8 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
                                                config_disabled_functions_reg,
                                                config_disabled_functions))) {
       }
-    } else if ((execute_data->prev_execute_data->opline->opcode ==
-                    ZEND_DO_FCALL ||
-                execute_data->prev_execute_data->opline->opcode ==
-                    ZEND_DO_UCALL ||
-                execute_data->prev_execute_data->opline->opcode ==
-                    ZEND_DO_ICALL ||
-                execute_data->prev_execute_data->opline->opcode ==
-                    ZEND_DO_FCALL_BY_NAME)) {
+    } else if (execute_data->prev_execute_data->opline->opcode ==
+               ZEND_DO_FCALL) {
       if (UNEXPECTED(true == should_disable_ht(execute_data, function_name,
                                                NULL, NULL,
                                                config_disabled_functions_reg,


### PR DESCRIPTION
Apparently, it's enough to hook only on `ZEND_DO_FCALL`.

It doesn't break the testsuite, but it would be nice to try this on some real web application, like wordpress or magento.

This should close #257 