### PR TITLE
Make the testsuite work on php7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   - phpize
   - ./configure --enable-snuffleupagus --enable-coverage
   - make -j 2
+  - sed -i "s/\$$ext_params -d display_errors=0 -r/-d display_errors=0 -r/" run-tests.php
   - TEST_PHP_ARGS="-q" REPORT_EXIT_STATUS=1 make test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   - ./configure --enable-snuffleupagus --enable-coverage
   - make -j 2
   - sed -i "s/\$$ext_params -d display_errors=0 -r/-d display_errors=0 -r/" run-tests.php
+  - cat run-tests.php
   - TEST_PHP_ARGS="-q" REPORT_EXIT_STATUS=1 make test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - phpize
   - ./configure --enable-snuffleupagus --enable-coverage
   - make -j 2
-  - sed -i "s/\$$ext_params -d display_errors=0 -r/-d display_errors=0 -r/" run-tests.php
+  - sed -i "s/\$ext_params -d display_errors=0 -r/-d display_errors=0 -r/" run-tests.php
   - cat run-tests.php
   - TEST_PHP_ARGS="-q" REPORT_EXIT_STATUS=1 make test
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ compile_debug:  ## compile a debug build
 	make -C src
 
 debug: compile_debug ## compile and run a debug build
+	sed -i "s/\$$ext_params -d display_errors=0 -r/-d display_errors=0 -r/" src/run-tests.php
 	TEST_PHP_ARGS='-q' REPORT_EXIT_STATUS=1 make -C src test
 
 coverage:  ## compile snuffleugpaus, and run the testsuite with coverage

--- a/src/tests/disable_function/disabled_function_ensure_client_valid_certs.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_client_valid_certs.phpt
@@ -5,6 +5,8 @@ Disable functions - Ensure that client certificates validation can't be disabled
 if (!extension_loaded("snuffleupagus")) { die("skip"); }
 if (!extension_loaded("curl")) { die("skip"); }
 ?>
+--EXTENSIONS--
+curl
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_curl_verify_certs.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_multi_setopt.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_multi_setopt.phpt
@@ -5,6 +5,8 @@ Disable functions - Ensure that client certificates validation can't be disabled
 if (!extension_loaded("snuffleupagus")) { die("skip"); }
 if (!extension_loaded("curl")) { die("skip"); }
 ?>
+--EXTENSIONS--
+curl
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_curl_verify_certs.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_setopt_array.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_setopt_array.phpt
@@ -5,6 +5,8 @@ Disable functions - Ensure that client certificates validation can't be disabled
 if (!extension_loaded("snuffleupagus")) { die("skip"); }
 if (!extension_loaded("curl")) { die("skip"); }
 ?>
+--EXTENSIONS--
+curl
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_curl_verify_certs.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_ensure_server_valid_certs.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_server_valid_certs.phpt
@@ -5,6 +5,8 @@ Disable functions - Ensure that server certificates validation can't be disabled
 if (!extension_loaded("snuffleupagus")) { die("skip"); }
 if (!extension_loaded("curl")) { die("skip"); }
 ?>
+--EXTENSIONS--
+curl
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_curl_verify_certs.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_ensure_server_valid_certs_curl_multi_setopt.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_server_valid_certs_curl_multi_setopt.phpt
@@ -5,6 +5,8 @@ Disable functions - Ensure that server certificates validation can't be disabled
 if (!extension_loaded("snuffleupagus")) { die("skip"); }
 if (!extension_loaded("curl")) { die("skip"); }
 ?>
+--EXTENSIONS--
+curl
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_curl_verify_certs.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_ensure_server_valid_certs_curl_setopt_array.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_server_valid_certs_curl_setopt_array.phpt
@@ -2,9 +2,11 @@
 Disable functions - Ensure that server certificates validation can't be disabled via `curl_setopt_array`
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) { die("skip"); }
-if (!extension_loaded("curl")) { die("skip"); }
+if (!extension_loaded("snuffleupagus")) { echo("skip"); }
+if (!extension_loaded("curl")) { echo("skip"); }
 ?>
+--EXTENSIONS--
+curl
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_curl_verify_certs.ini
 --FILE--

--- a/src/tests/xxe/disable_xxe_dom.phpt
+++ b/src/tests/xxe/disable_xxe_dom.phpt
@@ -8,6 +8,8 @@ Disable XXE
 	echo "skip";
 }
  ?>
+--EXTENSIONS--
+dom
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini
 --FILE--

--- a/src/tests/xxe/disable_xxe_dom_disabled.phpt
+++ b/src/tests/xxe/disable_xxe_dom_disabled.phpt
@@ -5,6 +5,8 @@ Disable XXE
  if (!extension_loaded("snuffleupagus")) echo "skip";
  if (!extension_loaded("dom")) echo "skip";
  ?>
+--extensions--
+dom
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe_disable.ini
 --FILE--

--- a/src/tests/xxe/disable_xxe_simplexml.phpt
+++ b/src/tests/xxe/disable_xxe_simplexml.phpt
@@ -6,7 +6,7 @@ Disable XXE
  if (!extension_loaded("simplexml")) echo "skip";
  ?>
 --EXTENSIONS--
-simplexml
+xml
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini
 --FILE--

--- a/src/tests/xxe/disable_xxe_simplexml.phpt
+++ b/src/tests/xxe/disable_xxe_simplexml.phpt
@@ -5,6 +5,8 @@ Disable XXE
  if (!extension_loaded("snuffleupagus")) echo "skip";
  if (!extension_loaded("simplexml")) echo "skip";
  ?>
+--EXTENSIONS--
+simplexml
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini
 --FILE--

--- a/src/tests/xxe/disable_xxe_simplexml_oop.phpt
+++ b/src/tests/xxe/disable_xxe_simplexml_oop.phpt
@@ -6,7 +6,7 @@ Disable XXE
  if (!extension_loaded("simplexml")) echo "skip";
  ?>
 --EXTENSIONS--
-simplexml
+xml
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini
 --FILE--

--- a/src/tests/xxe/disable_xxe_simplexml_oop.phpt
+++ b/src/tests/xxe/disable_xxe_simplexml_oop.phpt
@@ -5,6 +5,8 @@ Disable XXE
  if (!extension_loaded("snuffleupagus")) echo "skip";
  if (!extension_loaded("simplexml")) echo "skip";
  ?>
+--EXTENSIONS--
+simplexml
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini
 --FILE--

--- a/src/tests/xxe/disable_xxe_xml_parse.phpt
+++ b/src/tests/xxe/disable_xxe_xml_parse.phpt
@@ -8,6 +8,8 @@ Disable XXE in xml_parse
   echo "skip because the `xml` extension isn't loaded";
 }
  ?>
+--EXTENSIONS--
+xml
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini
 --FILE--


### PR DESCRIPTION
Php's testsuite macanism is running snippets to determine some runtime
parameters like the extension directory. Unfortunately, since php7.4+, it tries
to run them with Snuffleupagus loaded, resulting in an error, since no
configuration file is passed.