### PR TITLE
Don't call libxml_disable_entity_loader for php8+

### DIFF
--- a/src/sp_disable_xxe.c
+++ b/src/sp_disable_xxe.c
@@ -9,12 +9,15 @@ int hook_libxml_disable_entity_loader() {
 
   TSRMLS_FETCH();
 
+// External entities are disabled by default in PHP8+
+#if PHP_VERSION_ID < 80000
   /* Call the php function here instead of re-implementing it is a bit
    * ugly, but we do not want to introduce compile-time dependencies against
    * libxml. */
   ZVAL_STRING(&func_name, "libxml_disable_entity_loader");
   ZVAL_STRING(&params[0], "true");
   call_user_function(CG(function_table), NULL, &func_name, &hmac, 1, params);
+#endif
 
   HOOK_FUNCTION("libxml_disable_entity_loader", sp_internal_functions_hook,
                 PHP_FN(sp_libxml_disable_entity_loader));


### PR DESCRIPTION
This functions is deprecated, but since PHP8+ requires
libxml 2.9.0 where XXE are disabled by default,
there is no need to call it anymore.