### PR TITLE
Fix zend_write booking type

### DIFF
--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -626,7 +626,11 @@ int hook_disabled_functions(void) {
 
 zend_write_func_t zend_write_default = NULL;
 
+#if PHP_VERSION_ID >= 80000
+size_t hook_echo(const char* str, size_t str_length) {
+#else
 int hook_echo(const char* str, size_t str_length) {
+#endif
   zend_string* zs = zend_string_init(str, str_length, 0);
 
   should_disable_ht(

--- a/src/sp_disabled_functions.h
+++ b/src/sp_disabled_functions.h
@@ -3,8 +3,12 @@
 
 extern zend_write_func_t zend_write_default;
 
-int hook_disabled_functions(void);
+#if PHP_VERSION_ID >= 80000
+size_t hook_echo(const char *, size_t);
+#else
 int hook_echo(const char *, size_t);
+#endif
+int hook_disabled_functions(void);
 void should_disable_ht(zend_execute_data *, const char *, const zend_string *,
                        const char *, const sp_list_node *, const HashTable *);
 void should_drop_on_ret_ht(const zval *, const char *,


### PR DESCRIPTION
The signature was changed in PHP8: https://github.com/php/php-src/commit/e15409b43cacf711608189c299191f2969ea331c