### PR TITLE
In tests, don't `die("skip")` but `print "skip"` instead

### DIFF
--- a/src/tests/broken_configuration/broken_conf_invalid_filename.phpt
+++ b/src/tests/broken_configuration/broken_conf_invalid_filename.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Broken configuration filename without absolute path
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/broken_conf_invalid_filename.ini
 --FILE--

--- a/src/tests/broken_configuration/broken_conf_invalid_log_media.phpt
+++ b/src/tests/broken_configuration/broken_conf_invalid_log_media.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Broken configuration filename with improper log media
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/broken_conf_invalid_log_media.ini
 --FILE--

--- a/src/tests/broken_configuration/broken_conf_invalid_type.phpt
+++ b/src/tests/broken_configuration/broken_conf_invalid_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Broken conf with wrong type
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/broken_conf_invalid_type.ini
 --FILE--

--- a/src/tests/broken_configuration/broken_conf_wrong_type.phpt
+++ b/src/tests/broken_configuration/broken_conf_wrong_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Broken conf with wrong type
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/broken_conf_wrong_type.ini
 --FILE--

--- a/src/tests/broken_configuration/broken_invalid_client_ip4.phpt
+++ b/src/tests/broken_configuration/broken_invalid_client_ip4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Invalid client IP
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --ENV--
 return <<<EOF
 REMOTE_ADDR=xyz

--- a/src/tests/broken_configuration/broken_regexp.phpt
+++ b/src/tests/broken_configuration/broken_regexp.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Broken regexp
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/broken_regexp.ini
 --FILE--

--- a/src/tests/broken_configuration/broken_unmatching_brackets.phpt
+++ b/src/tests/broken_configuration/broken_unmatching_brackets.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Broken configuration - unmatching brackets
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_unmatching_brackets.ini
 --FILE--

--- a/src/tests/broken_configuration/encrypt_regexp_cookies_bad_regexp.phpt
+++ b/src/tests/broken_configuration/encrypt_regexp_cookies_bad_regexp.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie decryption in ipv4
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies_bad_regexp.ini
 error_reporting=1

--- a/src/tests/config_typo3.phpt
+++ b/src/tests/config_typo3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Rules for Typo3
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/../../config/typo3.rules
 --FILE--

--- a/src/tests/cookies_encryption/encrypt_cookies.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie decryption in ipv4
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_cookies2.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption in ipv4
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_cookies3.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie decryption with ipv6
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_cookies4.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption in ipv6
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_cookies_empty_env.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies_empty_env.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - empty environment variable specified
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies_empty_env.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - invalid decryption
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption2.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption3.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption_short_cookie.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption_short_cookie.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - invalid decryption in simulation mode with a short cookie
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies_simulation.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption_simulation.phpt
+++ b/src/tests/cookies_encryption/encrypt_cookies_invalid_decryption_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - invalid decryption in simulation mode
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies_simulation.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie decryption in ipv4
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies2.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption in ipv4
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies3.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie decryption with ipv6
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies4.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption in ipv6
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies_empty_env.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies_empty_env.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - empty environment variable specified
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies_empty_env.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies_invalid_decryption.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies_invalid_decryption.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies_invalid_decryption2.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies_invalid_decryption2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 display_errors=1

--- a/src/tests/cookies_encryption/encrypt_regexp_cookies_invalid_decryption3.phpt
+++ b/src/tests/cookies_encryption/encrypt_regexp_cookies_invalid_decryption3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_regexp_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption/setcookie.phpt
+++ b/src/tests/cookies_encryption/setcookie.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Set cookies.
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_encrypted_cookies.ini
 --COOKIE--

--- a/src/tests/cookies_encryption_warning/encrypt_cookies_no_env.phpt
+++ b/src/tests/cookies_encryption_warning/encrypt_cookies_no_env.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - no environment variable specified
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/encrypt_cookies_no_env.ini
 display_errors=1

--- a/src/tests/cookies_encryption_warning/encrypt_cookies_no_key.phpt
+++ b/src/tests/cookies_encryption_warning/encrypt_cookies_no_key.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - no encryption key specified
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/encrypt_cookies_no_key.ini
 display_errors=1

--- a/src/tests/cookies_encryption_warning/encrypt_regexp_cookies_no_env.phpt
+++ b/src/tests/cookies_encryption_warning/encrypt_regexp_cookies_no_env.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - no environment variable specified
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/encrypt_regexp_cookies_no_env.ini
 display_errors=1

--- a/src/tests/cookies_encryption_warning/encrypt_regexp_cookies_no_key.phpt
+++ b/src/tests/cookies_encryption_warning/encrypt_regexp_cookies_no_key.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Cookie encryption - no encryption key specified
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/encrypt_regexp_cookies_no_key.ini
 display_errors=1

--- a/src/tests/disable_function/disabled_function_echo.phpt
+++ b/src/tests/disable_function/disabled_function_echo.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Echo hooking
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_echo.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_echo_2.phpt
+++ b/src/tests/disable_function/disabled_function_echo_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Echo hooking
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_echo.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_echo_local_var.phpt
+++ b/src/tests/disable_function/disabled_function_echo_local_var.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Echo hooking
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_echo.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_ensure_client_valid_certs.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_client_valid_certs.phpt
@@ -2,8 +2,8 @@
 Disable functions - Ensure that client certificates validation can't be disabled
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) { die("skip"); }
-if (!extension_loaded("curl")) { die("skip"); }
+if (!extension_loaded("snuffleupagus")) { print("skip"); }
+if (!extension_loaded("curl")) { print("skip"); }
 ?>
 --EXTENSIONS--
 curl

--- a/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_multi_setopt.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_multi_setopt.phpt
@@ -2,8 +2,8 @@
 Disable functions - Ensure that client certificates validation can't be disabled via `curl_multi_setopt`
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) { die("skip"); }
-if (!extension_loaded("curl")) { die("skip"); }
+if (!extension_loaded("snuffleupagus")) { print("skip"); }
+if (!extension_loaded("curl")) { print("skip"); }
 ?>
 --EXTENSIONS--
 curl

--- a/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_setopt_array.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_client_valid_certs_curl_setopt_array.phpt
@@ -2,8 +2,8 @@
 Disable functions - Ensure that client certificates validation can't be disabled via `curl_setopt_array`
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) { die("skip"); }
-if (!extension_loaded("curl")) { die("skip"); }
+if (!extension_loaded("snuffleupagus")) { print("skip"); }
+if (!extension_loaded("curl")) { print("skip"); }
 ?>
 --EXTENSIONS--
 curl

--- a/src/tests/disable_function/disabled_function_ensure_server_valid_certs.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_server_valid_certs.phpt
@@ -2,8 +2,8 @@
 Disable functions - Ensure that server certificates validation can't be disabled
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) { die("skip"); }
-if (!extension_loaded("curl")) { die("skip"); }
+if (!extension_loaded("snuffleupagus")) { print("skip"); }
+if (!extension_loaded("curl")) { print("skip"); }
 ?>
 --EXTENSIONS--
 curl

--- a/src/tests/disable_function/disabled_function_ensure_server_valid_certs_curl_multi_setopt.phpt
+++ b/src/tests/disable_function/disabled_function_ensure_server_valid_certs_curl_multi_setopt.phpt
@@ -2,8 +2,8 @@
 Disable functions - Ensure that server certificates validation can't be disabled via `curl_multi_setopt`
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) { die("skip"); }
-if (!extension_loaded("curl")) { die("skip"); }
+if (!extension_loaded("snuffleupagus")) { print("skip"); }
+if (!extension_loaded("curl")) { print("skip"); }
 ?>
 --EXTENSIONS--
 curl

--- a/src/tests/disable_function/disabled_function_local_var.phpt
+++ b/src/tests/disable_function/disabled_function_local_var.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_10.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_10.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_2.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_3.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_4.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var_2.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_5.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_5.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_6.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_6.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_7.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_8.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_8.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_9.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_9.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_const.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_const.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a constant
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var_const.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_crash.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_crash.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_local_var_obj.phpt
+++ b/src/tests/disable_function/disabled_function_local_var_obj.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a local variable
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var_obj.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_param.phpt
+++ b/src/tests/disable_function/disabled_function_param.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a param
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_param.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_print.phpt
+++ b/src/tests/disable_function/disabled_function_print.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Echo hooking
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_print.ini
 --FILE--

--- a/src/tests/disable_function/disabled_function_super_global_var.phpt
+++ b/src/tests/disable_function/disabled_function_super_global_var.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a super global
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_super_global_var.ini
 --GET--

--- a/src/tests/disable_function/disabled_functions.phpt
+++ b/src/tests/disable_function/disabled_functions.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_callback_called_file_r.phpt
+++ b/src/tests/disable_function/disabled_functions_callback_called_file_r.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions by matching on the filename_r where the callback function is called, and not defined
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_callback_called_file_r.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_called_file_r.phpt
+++ b/src/tests/disable_function/disabled_functions_called_file_r.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions by matching on the filename_r where the function is called, and not defined
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_called_file_r.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_chain.phpt
+++ b/src/tests/disable_function/disabled_functions_chain.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions by matching the calltrace
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_chain.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_chain_call_skip.phpt
+++ b/src/tests/disable_function/disabled_functions_chain_call_skip.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions by matching the calltrace, with a superfluous function in between
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_chain_call_skip.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_chain_call_user_func.phpt
+++ b/src/tests/disable_function/disabled_functions_chain_call_user_func.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions by matching the calltrace, with call_user_func involved
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_chain_call_user_func.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_chain_call_user_func_ret.phpt
+++ b/src/tests/disable_function/disabled_functions_chain_call_user_func_ret.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions by matching the calltrace, on the return value
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_chain_call_user_func_ret.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_chain_not_matching.phpt
+++ b/src/tests/disable_function/disabled_functions_chain_not_matching.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions by matching the calltrace
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_chain.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_cidr.phpt
+++ b/src/tests/disable_function/disabled_functions_cidr.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --ENV--
 return <<<EOF
 REMOTE_ADDR=127.0.0.1

--- a/src/tests/disable_function/disabled_functions_cidr_6.phpt
+++ b/src/tests/disable_function/disabled_functions_cidr_6.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --ENV--
 return <<<EOF
 REMOTE_ADDR=2001:0db8:f000:f000:f000:ff00:0042:8328

--- a/src/tests/disable_function/disabled_functions_cidr_x_fwd_for.phpt
+++ b/src/tests/disable_function/disabled_functions_cidr_x_fwd_for.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - CIDR match on an x-forwarded-for
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --ENV--
 return <<<EOF
 HTTP_X_FORWARDED_FOR=127.0.0.1

--- a/src/tests/disable_function/disabled_functions_cidr_x_fwd_for_remote_addr.phpt
+++ b/src/tests/disable_function/disabled_functions_cidr_x_fwd_for_remote_addr.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - x-forwarded-for and remote-addr
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --ENV--
 return <<<EOF
 HTTP_X_FORWARDED_FOR=127.0.0.1

--- a/src/tests/disable_function/disabled_functions_die.phpt
+++ b/src/tests/disable_function/disabled_functions_die.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - die
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_die.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_drop_include.phpt
+++ b/src/tests/disable_function/disabled_functions_drop_include.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable function, bug : https://github.com/jvoisin/snuffleupagus/issues/181
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_drop_include.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_drop_include_simulation.phpt
+++ b/src/tests/disable_function/disabled_functions_drop_include_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable function, bug : https://github.com/jvoisin/snuffleupagus/issues/181
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_drop_include_simulation.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_eval.phpt
+++ b/src/tests/disable_function/disabled_functions_eval.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - eval
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_eval.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_eval_filename.phpt
+++ b/src/tests/disable_function/disabled_functions_eval_filename.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - eval
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_eval_filename.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_eval_simulation.phpt
+++ b/src/tests/disable_function/disabled_functions_eval_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - eval (simulation)
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_eval_simulation.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_eval_user.phpt
+++ b/src/tests/disable_function/disabled_functions_eval_user.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - eval with a disabled user func
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_eval_user_func.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_exit.phpt
+++ b/src/tests/disable_function/disabled_functions_exit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - exit
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_exit.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_filename_r.phpt
+++ b/src/tests/disable_function/disabled_functions_filename_r.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - filename regexp
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_filename_r.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_include_once.phpt
+++ b/src/tests/disable_function/disabled_functions_include_once.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - include_once
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_include.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_include_simulation.phpt
+++ b/src/tests/disable_function/disabled_functions_include_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - Include (simulation)
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_include.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_local_var_array.phpt
+++ b/src/tests/disable_function/disabled_functions_local_var_array.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array value buried in several levels
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_local_var_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_local_var_array_key.phpt
+++ b/src/tests/disable_function/disabled_functions_local_var_array_key.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array value buried in several levels
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_local_var_array_key.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_local_var_array_not_array.phpt
+++ b/src/tests/disable_function/disabled_functions_local_var_array_not_array.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_function_local_var_array_not_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_mb.phpt
+++ b/src/tests/disable_function/disabled_functions_mb.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_mb.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_method.phpt
+++ b/src/tests/disable_function/disabled_functions_method.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_method.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_name_r.phpt
+++ b/src/tests/disable_function/disabled_functions_name_r.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_name_r.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_name_regexp_type.phpt
+++ b/src/tests/disable_function/disabled_functions_name_regexp_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_name_regexp_type.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_name_type.phpt
+++ b/src/tests/disable_function/disabled_functions_name_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_name_type.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_namespace.phpt
+++ b/src/tests/disable_function/disabled_functions_namespace.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions in namespaces
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_namespace.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_noconf.phpt
+++ b/src/tests/disable_function/disabled_functions_noconf.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/empty.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_nul_byte.phpt
+++ b/src/tests/disable_function/disabled_functions_nul_byte.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions with nul byte
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_nul_byte.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param.phpt
+++ b/src/tests/disable_function/disabled_functions_param.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_alias.phpt
+++ b/src/tests/disable_function/disabled_functions_param_alias.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - alias
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_alias.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_allow.phpt
+++ b/src/tests/disable_function/disabled_functions_param_allow.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - allow
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_allow.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_deref.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_deref.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_no_value.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_no_value.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - matching on an array's variable only
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_r.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_r.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array using regexp
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_r_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_r_keys.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_r_keys.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array using regexp
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_r_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_several_levels.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_several_levels.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array value buried in several levels
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_several_levels_int.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_several_levels_int.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array value buried in several levels
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_several_levels_keys.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_several_levels_keys.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array value buried in several levels
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_array_several_levels_keys_int.phpt
+++ b/src/tests/disable_function/disabled_functions_param_array_several_levels_keys_int.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on an array value buried in several levels
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_broken_line.phpt
+++ b/src/tests/disable_function/disabled_functions_param_broken_line.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a specific line - broken configuration
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_broken_line.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_int.phpt
+++ b/src/tests/disable_function/disabled_functions_param_int.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_int.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_invalid_pos.phpt
+++ b/src/tests/disable_function/disabled_functions_param_invalid_pos.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on argument's position
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_invalid_pos.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_line.phpt
+++ b/src/tests/disable_function/disabled_functions_param_line.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on a specific line
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_line.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_pos.phpt
+++ b/src/tests/disable_function/disabled_functions_param_pos.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on argument's position
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_pos.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_pos2.phpt
+++ b/src/tests/disable_function/disabled_functions_param_pos2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on argument's position, not the first time
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_pos.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_r.phpt
+++ b/src/tests/disable_function/disabled_functions_param_r.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_r.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_param_str_representation.phpt
+++ b/src/tests/disable_function/disabled_functions_param_str_representation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - casting various types to string internally
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_str_representation.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_parse_class.phpt
+++ b/src/tests/disable_function/disabled_functions_parse_class.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - Parsing of an Object as a return value of a function
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_pos_type.phpt
+++ b/src/tests/disable_function/disabled_functions_pos_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - match on argument's position
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_pos.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_regexp_multiple.phpt
+++ b/src/tests/disable_function/disabled_functions_regexp_multiple.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_regexp.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_register_shutdown_function.phpt
+++ b/src/tests/disable_function/disabled_functions_register_shutdown_function.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - Called with register_shutdown_function
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_user_functions.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_register_tick_function.phpt
+++ b/src/tests/disable_function/disabled_functions_register_tick_function.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - Called with register_tick_function
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_user_functions.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_require.phpt
+++ b/src/tests/disable_function/disabled_functions_require.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - Require
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_require.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_require_allow.phpt
+++ b/src/tests/disable_function/disabled_functions_require_allow.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - Require (allow)
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_require_allow.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_require_once.phpt
+++ b/src/tests/disable_function/disabled_functions_require_once.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - require_once
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_require.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_require_simulation.phpt
+++ b/src/tests/disable_function/disabled_functions_require_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - Require (simulation)
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_require.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret.phpt
+++ b/src/tests/disable_function/disabled_functions_ret.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret`.
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret2.phpt
+++ b/src/tests/disable_function/disabled_functions_ret2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret`.
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret3.phpt
+++ b/src/tests/disable_function/disabled_functions_ret3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret`.
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret.ini
 memory_limit=-1

--- a/src/tests/disable_function/disabled_functions_ret_allow.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_allow.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret`.
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_ret_allow.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_allow_value.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_allow_value.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` allowed
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_ret_allow_value.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_right_hash.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_right_hash.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_ret_right_hash.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_simulation.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` simulation
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_ret_simulation.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (false)
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_array.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_array.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (array).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_array.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_double.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_double.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (double).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_double.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_long.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_long.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (long).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_long.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_null.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_null.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (null).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_null.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_object.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_object.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (object).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_object.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_resource.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_resource.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (resource).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_resource.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_str.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_str.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (string).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_str.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_type_true.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_type_true.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` by type matching (true).
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_ret_type_true.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_user.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_user.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Check NULL return value for user func
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_ret_user.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_user_used.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_user_used.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Check return value for user func
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_ret_user.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_val.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_val.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions ret val
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_retval.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_ret_val_dump.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_val_dump.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions ret val - dump
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_retval_dump.ini
 --ENV--

--- a/src/tests/disable_function/disabled_functions_ret_val_rx.phpt
+++ b/src/tests/disable_function/disabled_functions_ret_val_rx.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions ret val rx
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_retval_rx.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_right_hash.phpt
+++ b/src/tests/disable_function/disabled_functions_right_hash.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_right_hash.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_runtime.phpt
+++ b/src/tests/disable_function/disabled_functions_runtime.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - runtime inclusion
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_param_runtime.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_upper.phpt
+++ b/src/tests/disable_function/disabled_functions_upper.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - uppercase
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_variadic.phpt
+++ b/src/tests/disable_function/disabled_functions_variadic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions - support for variadic functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_functions_variadic.ini
 --FILE--

--- a/src/tests/disable_function/disabled_functions_zero_cidr.phpt
+++ b/src/tests/disable_function/disabled_functions_zero_cidr.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --ENV--
 return <<<EOF
 REMOTE_ADDR=127.0.0.1

--- a/src/tests/disable_function/disabled_native_functions_indirect.phpt
+++ b/src/tests/disable_function/disabled_native_functions_indirect.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disabled native functions, called indirectly
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions.ini
 --FILE--

--- a/src/tests/disable_function/disabled_user_functions.phpt
+++ b/src/tests/disable_function/disabled_user_functions.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disabled user-created functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_user_functions.ini
 --FILE--

--- a/src/tests/disable_function/disabled_user_functions_indirect.phpt
+++ b/src/tests/disable_function/disabled_user_functions_indirect.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disabled user-created functions, called indirectly
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_disabled_user_functions.ini
 --FILE--

--- a/src/tests/dump_request/dump_eval_blacklist.phpt
+++ b/src/tests/dump_request/dump_eval_blacklist.phpt
@@ -2,7 +2,7 @@
 Dump eval blacklist
 --SKIPIF--
 <?php 
-if (!extension_loaded("snuffleupagus")) die "skip";
+if (!extension_loaded("snuffleupagus")) print "skip";
 ?>
 --POST--
 post_a=data_post_a&post_b=data_post_b

--- a/src/tests/dump_request/dump_eval_whitelist.phpt
+++ b/src/tests/dump_request/dump_eval_whitelist.phpt
@@ -2,7 +2,7 @@
 Dump eval whitelist
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) die "skip";
+if (!extension_loaded("snuffleupagus")) print "skip";
 ?>
 --POST--
 post_a=data_post_a&post_b=data_post_b

--- a/src/tests/dump_request/dump_segfault1.phpt
+++ b/src/tests/dump_request/dump_segfault1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Disable functions check on `ret` with an alias
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_dump_segfault1.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_backlist.phpt
+++ b/src/tests/eval_blacklist/eval_backlist.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval blacklist
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_backlist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_backlist_call_user_func.phpt
+++ b/src/tests/eval_blacklist/eval_backlist_call_user_func.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval blacklist - with several calls in an eval.
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_backlist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_backlist_chained.phpt
+++ b/src/tests/eval_blacklist/eval_backlist_chained.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval blacklist - with several calls in an eval.
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_backlist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_backlist_list.phpt
+++ b/src/tests/eval_blacklist/eval_backlist_list.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval blacklist - with a list of functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_backlist_list.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_backlist_simulation.phpt
+++ b/src/tests/eval_blacklist/eval_backlist_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval blacklist simulation
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_backlist_simulation.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_backlist_whitelist.phpt
+++ b/src/tests/eval_blacklist/eval_backlist_whitelist.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval whitelist
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_whitelist_blacklist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_backlist_whitelist_builtin.phpt
+++ b/src/tests/eval_blacklist/eval_backlist_whitelist_builtin.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval whitelist/blacklist, on builtin functions
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_whitelist_blacklist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_whitelist.phpt
+++ b/src/tests/eval_blacklist/eval_whitelist.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval whitelist
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_whitelist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_whitelist_builtin.phpt
+++ b/src/tests/eval_blacklist/eval_whitelist_builtin.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval whitelist - builtin function
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_whitelist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_whitelist_include_then_user.phpt
+++ b/src/tests/eval_blacklist/eval_whitelist_include_then_user.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval whitelist - builtin function
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_whitelist.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_whitelist_simulation.phpt
+++ b/src/tests/eval_blacklist/eval_whitelist_simulation.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval whitelist simulation
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_whitelist_simulation.ini
 --FILE--

--- a/src/tests/eval_blacklist/eval_whitelist_user_then_builtin.phpt
+++ b/src/tests/eval_blacklist/eval_whitelist_user_then_builtin.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval whitelist - builtin function
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_whitelist.ini
 --FILE--

--- a/src/tests/eval_blacklist/nested_eval_blacklist.phpt
+++ b/src/tests/eval_blacklist/nested_eval_blacklist.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval blacklist - nested eval
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_backlist.ini
 --FILE--

--- a/src/tests/eval_blacklist/nested_eval_blacklist2.phpt
+++ b/src/tests/eval_blacklist/nested_eval_blacklist2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Eval blacklist - nested eval, with a twist
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/eval_backlist.ini
 --FILE--

--- a/src/tests/glob_config.phpt
+++ b/src/tests/glob_config.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Multiple configuration files
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_multi*.ini
 --FILE--

--- a/src/tests/multi_config.phpt
+++ b/src/tests/multi_config.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Multiple configuration files
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_multi2.ini,{PWD}/config/config_multi1.ini
 --FILE--

--- a/src/tests/rips_configuration.phpt
+++ b/src/tests/rips_configuration.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Shipped configuration (rips)
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/../../config/rips.rules
 --FILE--

--- a/src/tests/samesite_cookies.phpt
+++ b/src/tests/samesite_cookies.phpt
@@ -2,7 +2,7 @@
 Cookie samesite
 --SKIPIF--
 <?php
-if (!extension_loaded("snuffleupagus")) die("skip");
+if (!extension_loaded("snuffleupagus")) print("skip");
 ?>
 --INI--
 sp.configuration_file={PWD}/config/config_samesite_cookies.ini

--- a/src/tests/session_encryption/crypt_session_corrupted_session.phpt
+++ b/src/tests/session_encryption/crypt_session_corrupted_session.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Set a custom session handler
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session.ini
 session.save_path = "/tmp"

--- a/src/tests/session_encryption/crypt_session_invalid.phpt
+++ b/src/tests/session_encryption/crypt_session_invalid.phpt
@@ -1,7 +1,7 @@
 --TEST--
 SESSION crypt and bad decrypt
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session.ini
 --ENV--

--- a/src/tests/session_encryption/crypt_session_invalid_simul.phpt
+++ b/src/tests/session_encryption/crypt_session_invalid_simul.phpt
@@ -1,7 +1,7 @@
 --TEST--
 SESSION crypt and bad decrypt
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session_simul.ini
 --ENV--

--- a/src/tests/session_encryption/crypt_session_read_uncrypt.phpt
+++ b/src/tests/session_encryption/crypt_session_read_uncrypt.phpt
@@ -1,7 +1,7 @@
 --TEST--
 SESSION crypt/decrypt valid
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session_simul.ini
 --ENV--

--- a/src/tests/session_encryption/crypt_session_valid.phpt
+++ b/src/tests/session_encryption/crypt_session_valid.phpt
@@ -1,7 +1,7 @@
 --TEST--
 SESSION crypt/decrypt valid
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session.ini
 --ENV--

--- a/src/tests/session_encryption/crypt_session_valid_simul.phpt
+++ b/src/tests/session_encryption/crypt_session_valid_simul.phpt
@@ -1,7 +1,7 @@
 --TEST--
 SESSION crypt/decrypt valid
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session_simul.ini
 --ENV--

--- a/src/tests/session_encryption/set_custom_session_handler.phpt
+++ b/src/tests/session_encryption/set_custom_session_handler.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Set a custom session handler
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session.ini
 session.save_path = "/tmp"

--- a/src/tests/session_encryption/set_custom_session_handler2.phpt
+++ b/src/tests/session_encryption/set_custom_session_handler2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Set a custom session handler, twice
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session.ini
 session.save_path = "/tmp"

--- a/src/tests/session_encryption/set_custom_session_handler_ini.phpt
+++ b/src/tests/session_encryption/set_custom_session_handler_ini.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Set a custom session handler
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/config_crypt_session.ini
 session.save_handler = 

--- a/src/tests/shipped_configuration.phpt
+++ b/src/tests/shipped_configuration.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Shipped configuration
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/../../config/default.rules
 --FILE--

--- a/src/tests/stream_wrapper/stream_wrapper_restore.phpt
+++ b/src/tests/stream_wrapper/stream_wrapper_restore.phpt
@@ -2,7 +2,7 @@
 Stream wrapper
 --SKIPIF--
 <?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
-<?php if (PHP_VERSION_ID >= 70300) { die("skip BROKEN with 7.3"); } ?>
+<?php if (PHP_VERSION_ID >= 70300) { print "skip BROKEN with 7.3"; } ?>
 --INI--
 sp.configuration_file={PWD}/config/config_stream_wrapper_register.ini
 --FILE--

--- a/src/tests/upload_validation/upload_validation_real.phpt
+++ b/src/tests/upload_validation/upload_validation_real.phpt
@@ -7,7 +7,7 @@ if (!extension_loaded("snuffleupagus")) {
 }
 
 if (PHP_VERSION_ID >= 70300) {
-  die("skip BROKEN with 7.3");
+  print "skip BROKEN with 7.3";
 }
 
 if (strpos(system(PHP_BINARY . " -d error_log=/dev/null -d extension=vld.so -m 2>/dev/null"), "vld") === FALSE) {


### PR DESCRIPTION
This is required since the `die` is making php8 choke