### PR TITLE
Add a check on parameters names

### DIFF
--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -197,14 +197,6 @@ static bool is_param_matching(zend_execute_data* execute_data,
                                 config_node->r_value)) {
         return true;
       }
-    } else {
-      char* complete_function_path = get_complete_function_path(execute_data);
-      sp_log_warn("config",
-                  "It seems that you are filtering on a parameter "
-                  "'%s' of the function '%s', but the parameter does "
-                  "not exists.",
-                  *arg_name, complete_function_path);
-      efree(complete_function_path);
     }
   }
   return false;

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -204,6 +204,7 @@ static bool is_param_matching(zend_execute_data* execute_data,
                   "'%s' of the function '%s', but the parameter does "
                   "not exists.",
                   *arg_name, complete_function_path);
+      efree(complete_function_path);
     }
   }
   return false;

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -197,6 +197,13 @@ static bool is_param_matching(zend_execute_data* execute_data,
                                 config_node->r_value)) {
         return true;
       }
+    } else {
+      char* complete_function_path = get_complete_function_path(execute_data);
+      sp_log_warn("config",
+                  "It seems that you are filtering on a parameter "
+                  "'%s' of the function '%s', but the parameter does "
+                  "not exists.",
+                  *arg_name, complete_function_path);
     }
   }
   return false;

--- a/src/sp_var_value.c
+++ b/src/sp_var_value.c
@@ -71,6 +71,11 @@ static zval *get_var_value(zend_execute_data *ed, const char *var_name,
   if (is_param) {
     zval *zvalue = get_param_var(ed, var_name);
     if (!zvalue) {
+      sp_log_warn("config",
+                  "It seems that you are filtering on a parameter "
+                  "that does not exists: \"%s\". "
+                  "Matching on local variables instead.",
+                  var_name);
       return get_local_var(ed, var_name);
     }
     return zvalue;

--- a/src/sp_var_value.c
+++ b/src/sp_var_value.c
@@ -71,6 +71,13 @@ static zval *get_var_value(zend_execute_data *ed, const char *var_name,
   if (is_param) {
     zval *zvalue = get_param_var(ed, var_name);
     if (!zvalue) {
+      char* complete_function_path = get_complete_function_path(ed);
+      sp_log_warn("config",
+                  "It seems that you are filtering on a parameter "
+                  "'%s' of the function '%s', but the parameter does "
+                  "not exists.",
+                  var_name, complete_function_path);
+      efree(complete_function_path);
       return NULL;
     }
     return zvalue;

--- a/src/sp_var_value.c
+++ b/src/sp_var_value.c
@@ -71,12 +71,7 @@ static zval *get_var_value(zend_execute_data *ed, const char *var_name,
   if (is_param) {
     zval *zvalue = get_param_var(ed, var_name);
     if (!zvalue) {
-      sp_log_warn("config",
-                  "It seems that you are filtering on a parameter "
-                  "that does not exists: \"%s\". "
-                  "Matching on local variables instead.",
-                  var_name);
-      return get_local_var(ed, var_name);
+      return NULL;
     }
     return zvalue;
   }

--- a/src/tests/broken_configuration/broken_conf_config_invalid_param.phpt
+++ b/src/tests/broken_configuration/broken_conf_config_invalid_param.phpt
@@ -1,15 +1,16 @@
 --TEST--
-Broken configuration, with invalid parameter warning
+Broken configuration with invalid parameter warning
 --SKIPIF--
 <?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/broken_conf_config_invalid_param.ini
 --FILE--
+<?php
 function foo($blah, $x = null, $y = null) {
   echo "ok";
 }
 
 foo("qwe");
---EXPECT--
-PHP Warning:  [snuffleupagus][0.0.0.0][config][log] It seems that you are filtering on a parameter '$qwe' of the function 'foo', but the parameter does not exists. in /tmp/test.php on line 3
+--EXPECTF--
+Warning: [snuffleupagus][0.0.0.0][config][log] It seems that you are filtering on a parameter '$qwe' of the function 'foo', but the parameter does not exists. in %s/tests/broken_configuration/broken_conf_config_invalid_param.php on line %d
 ok

--- a/src/tests/broken_configuration/broken_conf_config_invalid_param.phpt
+++ b/src/tests/broken_configuration/broken_conf_config_invalid_param.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Broken configuration, with invalid parameter warning
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/broken_conf_config_invalid_param.ini
+--FILE--
+function foo($blah, $x = null, $y = null) {
+  echo "ok";
+}
+
+foo("qwe");
+--EXPECT--
+PHP Warning:  [snuffleupagus][0.0.0.0][config][log] It seems that you are filtering on a parameter '$qwe' of the function 'foo', but the parameter does not exists. in /tmp/test.php on line 3
+ok

--- a/src/tests/broken_configuration/config/broken_conf_config_invalid_param.ini
+++ b/src/tests/broken_configuration/config/broken_conf_config_invalid_param.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("foo").param("qwe").value("abc").drop()

--- a/src/tests/disable_function/config/config_disabled_functions_param_array.ini
+++ b/src/tests/disable_function/config/config_disabled_functions_param_array.ini
@@ -4,4 +4,3 @@ sp.disable_function.function("foo").param("arr[test]").alias("3").drop();
 sp.disable_function.function("foo").param("arr[test2][foo]").value("aaa").alias("4").drop();
 sp.disable_function.function("foo").param("arr[test2][bar]").key("lol").alias("5").drop();
 sp.disable_function.function("foo").param("arr[test2][bar]").key("123").alias("6").drop();
-sp.disable_function.function("foo").param("qwe[a]").value("abcd").alias("7").drop();


### PR DESCRIPTION
I added a warning when the parameter name is not found as mentioned in #313 .

```
PHP Warning:  [snuffleupagus][0.0.0.0][config][log] It seems that you are filtering on a parameter '$qwe' of the function 'foo', but the parameter does not exists. in /tmp/test.php on line 3.
```