### PR TITLE
Add php8.0-dev option for making a debian install

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: snuffleupagus
 Priority: optional
 Maintainer: Julien (jvoisin) Voisin <julien.voisin+snuffleupagus@dustri.org>
-Build-Depends: debhelper (>= 9), php-curl, php-xml, php7.0-dev | php7.1-dev | php7.2-dev | php7.3-dev | php7.4-dev
+Build-Depends: debhelper (>= 9), php-curl, php-xml, php7.0-dev | php7.1-dev | php7.2-dev | php7.3-dev | php7.4-dev | php8.0-dev
 Standards-Version: 4.1.3
 Homepage: https://github.com/jvoisin/snuffleupagus
 Section: php


### PR DESCRIPTION
Added PHP8 as optional requirement... should we remove EOL PHP versions?