### PR TITLE
Fix SKIPIF output syntax error

### DIFF
--- a/src/tests/deny_writable/deny_writable_execution_simulation.phpt
+++ b/src/tests/deny_writable/deny_writable_execution_simulation.phpt
@@ -3,7 +3,7 @@ Readonly execution attempt (simulation mode)
 --SKIPIF--
 <?php if (PHP_VERSION_ID >= 80000) print "skip"; ?>
 <?php
-if (!extension_loaded("snuffleupagus")) { print "skip" };
+if (!extension_loaded("snuffleupagus")) { print "skip"; };
 
 // root has write privileges on any file
 if (TRUE == function_exists("posix_getuid")) {


### PR DESCRIPTION
Narrowed down #380 to a missing semicolon 🙃 