### PR TITLE
Update some parameter names which changed for PHP 8.0

### DIFF
--- a/config/default_php8.rules
+++ b/config/default_php8.rules
@@ -23,7 +23,7 @@ sp.disable_xxe.enable();
 # Only allow execution of read-only files. This is a low-hanging fruit that you should enable.
 # sp.readonly_exec.enable();
 
-# Php has a lot of wrappers, most of them aren't usually useful, you should 
+# Php has a lot of wrappers, most of them aren't usually useful, you should
 # only enable the ones you're using.
 # sp.wrappers_whitelist.list("file,php,phar");
 
@@ -41,14 +41,14 @@ sp.disable_function.function("chmod").param("mode").value_r("^[0-9]{2}[67]$").dr
 sp.disable_function.function("mail").param("additional_parameters").value_r("\\-").drop();
 
 # Since it's now burned, me might as well mitigate it publicly
-sp.disable_function.function("putenv").param("setting").value_r("LD_").drop()
+sp.disable_function.function("putenv").param("assignment").value_r("LD_").drop()
 
 # This one was burned in Nov 2019 - https://gist.github.com/LoadLow/90b60bd5535d6c3927bb24d5f9955b80
-sp.disable_function.function("putenv").param("setting").value_r("GCONV_").drop()
+sp.disable_function.function("putenv").param("assignment").value_r("GCONV_").drop()
 
 # Since people are stupid enough to use `extract` on things like $_GET or $_POST, we might as well mitigate this vector
-sp.disable_function.function("extract").param("var_array").value_r("^_").drop()
-sp.disable_function.function("extract").param("extract_type").value("0").drop()
+sp.disable_function.function("extract").param("array").value_r("^_").drop()
+sp.disable_function.function("extract").param("flags").value("0").drop()
 
 # This is also burned:
 # ini_set('open_basedir','..');chdir('..');…;chdir('..');ini_set('open_basedir','/');echo(file_get_contents('/etc/passwd'));
@@ -80,22 +80,22 @@ sp.disable_function.function("ini_set").param("option").value("memory_limit").dr
 sp.disable_function.function("ini_set").param("option").value("include_path").drop();
 sp.disable_function.function("ini_set").param("option").value("open_basedir").drop();
 
-# Detect some backdoors via environnement recon
-sp.disable_function.function("ini_get").param("varname").value("allow_url_fopen").drop();
-sp.disable_function.function("ini_get").param("varname").value("open_basedir").drop();
-sp.disable_function.function("ini_get").param("varname").value_r("suhosin").drop();
+# Detect some backdoors via environment recon
+sp.disable_function.function("ini_get").param("option").value("allow_url_fopen").drop();
+sp.disable_function.function("ini_get").param("option").value("open_basedir").drop();
+sp.disable_function.function("ini_get").param("option").value_r("suhosin").drop();
 sp.disable_function.function("function_exists").param("function").value("eval").drop();
 sp.disable_function.function("function_exists").param("function").value("exec").drop();
 sp.disable_function.function("function_exists").param("function").value("system").drop();
 sp.disable_function.function("function_exists").param("function").value("shell_exec").drop();
 sp.disable_function.function("function_exists").param("function").value("proc_open").drop();
 sp.disable_function.function("function_exists").param("function").value("passthru").drop();
-sp.disable_function.function("is_callable").param("var").value("eval").drop();
-sp.disable_function.function("is_callable").param("var").value("exec").drop();
-sp.disable_function.function("is_callable").param("var").value("system").drop();
-sp.disable_function.function("is_callable").param("var").value("shell_exec").drop();
-sp.disable_function.function("is_callable").param("var").value("proc_open").drop();
-sp.disable_function.function("is_callable").param("var").value("passthru").drop();
+sp.disable_function.function("is_callable").param("value").value("eval").drop();
+sp.disable_function.function("is_callable").param("value").value("exec").drop();
+sp.disable_function.function("is_callable").param("value").value("system").drop();
+sp.disable_function.function("is_callable").param("value").value("shell_exec").drop();
+sp.disable_function.function("is_callable").param("value").value("proc_open").drop();
+sp.disable_function.function("is_callable").param("value").value("passthru").drop();
 
 # Commenting sqli related stuff to improve performance.
 # TODO figure out why these functions can't be hooked at startup
@@ -136,7 +136,7 @@ sp.disable_function.function("curl_setopt").param("value").value("2").allow();
 sp.disable_function.function("curl_setopt").param("option").value("64").drop().alias("Please don't turn CURLOPT_SSL_VERIFYCLIENT off.");
 sp.disable_function.function("curl_setopt").param("option").value("81").drop().alias("Please don't turn CURLOPT_SSL_VERIFYHOST off.");
 
-#File upload
+# File upload
 sp.disable_function.function("move_uploaded_file").param("destination").value_r("\\.ph").drop();
 sp.disable_function.function("move_uploaded_file").param("destination").value_r("\\.ht").drop();
 


### PR DESCRIPTION
As per title, I believe these were forgotten (or not done yet) parameter name updates which confused me a fair bit 😅 

I double-checked the official doc to see that it wasn't an issue only on my local env and afaik the changes are correct as per:
- putenv https://www.php.net/manual/en/function.putenv.php
- extract https://www.php.net/manual/en/function.extract.php
- ini_get https://www.php.net/manual/en/function.ini-get
- is_callable https://www.php.net/manual/en/function.is-callable

Thanks