### PR TITLE
PHP 8 arg name fixes

### DIFF
--- a/config/default_php8.rules
+++ b/config/default_php8.rules
@@ -35,7 +35,7 @@ sp.disable_xxe.enable();
 sp.cookie.name("PHPSESSID").samesite("lax");
 
 # Harden the `chmod` function
-sp.disable_function.function("chmod").param("mode").value_r("^[0-9]{2}[67]$").drop();
+sp.disable_function.function("chmod").param("permissions").value_r("^[0-9]{2}[67]$").drop();
 
 # Prevent various `mail`-related vulnerabilities
 sp.disable_function.function("mail").param("additional_parameters").value_r("\\-").drop();


### PR DESCRIPTION
Seems like I had forgotten one such argument (well, at least 1 more) in my previous update MR for these, cf https://www.php.net/manual/en/function.chmod.php