### PR TITLE
Fix warning when SP_HAS_PCRE2 is not defined

### DIFF
--- a/src/sp_pcre_compat.c
+++ b/src/sp_pcre_compat.c
@@ -3,8 +3,9 @@
 inline void sp_pcre_free(sp_pcre* regexp) {
 #ifdef SP_HAS_PCRE2
   pcre2_code_free(regexp);
+#else
+  (void)regexp;
 #endif
-  regexp = NULL;
 }
 
 sp_pcre* sp_pcre_compile(const char* const pattern) {


### PR DESCRIPTION
Fixes the following warning

```
snuffleupagus/src/sp_pcre_compat.c: In function 'sp_pcre_free':
snuffleupagus/src/sp_pcre_compat.c:3:35: warning: parameter 'regexp' set but not used [-Wunused-but-set-parameter]
 inline void sp_pcre_free(sp_pcre* regexp) {
 ```