### PR TITLE
PHP8 update parameters name in "move_uploaded_file"

### DIFF
--- a/config/default_php8.rules
+++ b/config/default_php8.rules
@@ -111,8 +111,8 @@ sp.disable_function.function("curl_setopt").param("option").value("64").drop().a
 sp.disable_function.function("curl_setopt").param("option").value("81").drop().alias("Please don't turn CURLOPT_SSL_VERIFYHOST off.");
 
 # File upload
-sp.disable_function.function("move_uploaded_file").param("destination").value_r("\\.ph").drop();
-sp.disable_function.function("move_uploaded_file").param("destination").value_r("\\.ht").drop();
+sp.disable_function.function("move_uploaded_file").param("to").value_r("\\.ph").drop();
+sp.disable_function.function("move_uploaded_file").param("to").value_r("\\.ht").drop();
 
 # Logging lockdown
 sp.disable_function.function("ini_set").param("option").value_r("error_log").drop()


### PR DESCRIPTION
In the 8.0.8 and 8.1 version of PHP, the parameters name for move_uploaded_file are "from" and "to". This config file fail to apply the relevant rules unless the parameter names are updated using "to" instead of "destination".