### PR TITLE
only set orig_register_server_variables once

### DIFF
--- a/src/sp_ifilter.c
+++ b/src/sp_ifilter.c
@@ -97,7 +97,7 @@ static void sp_register_server_variables(zval *track_vars_array) {
 
 void sp_hook_register_server_variables()
 {
-  if (sapi_module.register_server_variables) {
+  if (sapi_module.register_server_variables && sapi_module.register_server_variables != sp_register_server_variables) {
     orig_register_server_variables = sapi_module.register_server_variables;
     sapi_module.register_server_variables = sp_register_server_variables;
   }


### PR DESCRIPTION
See #421 

When `sp.configuration_file` is overridden (first in php.ini, later using php_admin_value), `sp_hook_register_server_variables` is called twice, raising a infinite loop
(`orig_register_server_variables == sp_register_server_variables`)