### PR TITLE
Fix ZTS build

### DIFF
--- a/src/sp_config.c
+++ b/src/sp_config.c
@@ -6,7 +6,7 @@
 
 
 static zend_result sp_process_config_root(sp_parsed_keyword *parsed_rule) {
-  static const sp_config_keyword sp_func[] = {
+  sp_config_keyword sp_func[] = {
     {parse_unserialize,         SP_TOKEN_UNSERIALIZE_HMAC, &(SPCFG(unserialize))},
     {parse_enable,              SP_TOKEN_HARDEN_RANDOM, &(SPCFG(random).enable)},
     {parse_log_media,           SP_TOKEN_LOG_MEDIA, &(SPCFG(log_media))},


### PR DESCRIPTION
Since commit https://github.com/jvoisin/snuffleupagus/commit/7c2d1d7d2713c0fa6bda63c376baf25d9f3d712c 
The compilation with ZTS enabled fail with errors like
```
/home/iamluc/Dev/snuffleupagus/src/sp_config.c: In function ‘sp_process_config_root’:
/home/iamluc/Dev/snuffleupagus/src/sp_config.c:10:60: error: initializer element is not constant
   10 |     {parse_unserialize,         SP_TOKEN_UNSERIALIZE_HMAC, &(SPCFG(unserialize))},
```
