### PR TITLE
Revert "Minor refactor" (90bdf390) causing ZTS build failure

### DIFF
--- a/src/sp_config.c
+++ b/src/sp_config.c
@@ -4,7 +4,9 @@
 
 #include "php_snuffleupagus.h"
 
-static const sp_config_keyword sp_func[] = {
+
+static zend_result sp_process_config_root(sp_parsed_keyword *parsed_rule) {
+  sp_config_keyword sp_func[] = {
     {parse_unserialize,         SP_TOKEN_UNSERIALIZE_HMAC, &(SPCFG(unserialize))},
     {parse_enable,              SP_TOKEN_HARDEN_RANDOM, &(SPCFG(random).enable)},
     {parse_log_media,           SP_TOKEN_LOG_MEDIA, &(SPCFG(log_media))},
@@ -23,10 +25,7 @@ static const sp_config_keyword sp_func[] = {
     {parse_wrapper_whitelist,   SP_TOKEN_ALLOW_WRAPPERS, &(SPCFG(wrapper))},
     {parse_ini_protection,      SP_TOKEN_INI_PROTECTION, &(SPCFG(ini))},
     {parse_ini_entry,           SP_TOKEN_INI, NULL},
-    {NULL, NULL, NULL}
-};
-
-static zend_result sp_process_config_root(sp_parsed_keyword *parsed_rule) {
+    {NULL, NULL, NULL}};
   return sp_process_rule(parsed_rule, sp_func);
 }
 


### PR DESCRIPTION
This reverts commit 90bdf39000d2f09534b387d39203819995fb948e.

Caused compilation failure with PHP compiled with ZTS.
