### PR TITLE
Improve how the parser is generated

### DIFF
--- a/src/Makefile.frag
+++ b/src/Makefile.frag
@@ -1,7 +1,7 @@
 $(srcdir)/sp_config_scanner.c: $(srcdir)/sp_config_scanner.re
 	if re2c -v |grep ' [23]\.' 2>/dev/null; then \
-		re2c -bc -o $@ $<; \
-		re2c --no-generation-date --no-version -bci -o $(srcdir)/sp_config_scanner.cached.c $<; \
+		re2c -W --conditions --bit-vectors --no-debug-info --output $@ $<; \
+		re2c -W --no-generation-date --bit-vectors --no-version --conditions --no-debug-info --output $(srcdir)/sp_config_scanner.cached.c $<; \
 	else \
 		cp $(srcdir)/sp_config_scanner.cached.c $@; \
 	fi;

--- a/src/sp_config_scanner.h
+++ b/src/sp_config_scanner.h
@@ -18,7 +18,7 @@ typedef struct {
   long lineno;
 } sp_parsed_keyword;
 
-zend_result sp_config_scan(char *data, zend_result (*process_rule)(sp_parsed_keyword*));
+zend_result sp_config_scan(const char *data, zend_result (*process_rule)(sp_parsed_keyword*));
 zend_string *sp_get_arg_string(sp_parsed_keyword const *const kw);
 zend_string *sp_get_textual_representation(sp_parsed_keyword const *const parsed_rule);
 

--- a/src/tests/broken_configuration/broken_conf.phpt
+++ b/src/tests/broken_configuration/broken_conf.phpt
@@ -7,7 +7,7 @@ sp.configuration_file={PWD}/config/broken_conf.ini
 error_log=/dev/null
 --FILE--
 --EXPECT--
-Fatal error: [snuffleupagus][0.0.0.0][config][log] Parser error on line 1 in Unknown on line 0
+Fatal error: [snuffleupagus][0.0.0.0][config][log] parser error on line 1 in Unknown on line 0
 
 Fatal error: [snuffleupagus][0.0.0.0][config][log] Invalid configuration file in Unknown on line 0
 Could not startup.

--- a/src/tests/broken_configuration/broken_conf_allow_broken_disabled.phpt
+++ b/src/tests/broken_configuration/broken_conf_allow_broken_disabled.phpt
@@ -11,7 +11,7 @@ error_log=/dev/null
 echo 1337;
 ?>
 --EXPECT--
-Fatal error: [snuffleupagus][0.0.0.0][config][log] Parser error on line 1 in Unknown on line 0
+Fatal error: [snuffleupagus][0.0.0.0][config][log] parser error on line 1 in Unknown on line 0
 
 Fatal error: [snuffleupagus][0.0.0.0][config][log] Invalid configuration file in Unknown on line 0
 Could not startup.

--- a/src/tests/broken_configuration/broken_conf_allow_broken_enabled.phpt
+++ b/src/tests/broken_configuration/broken_conf_allow_broken_enabled.phpt
@@ -11,5 +11,5 @@ error_log=/dev/null
 echo 1337;
 ?>
 --EXPECT--
-Fatal error: [snuffleupagus][0.0.0.0][config][log] Parser error on line 1 in Unknown on line 0
+Fatal error: [snuffleupagus][0.0.0.0][config][log] parser error on line 1 in Unknown on line 0
 1337


### PR DESCRIPTION
- use long variant of options for re2c in its makefile
- use `define` instead of magic numbers
- add some consts
- trailing `;` are now mandatory for conditions
- NULL bytes are no longer allowed in configuration file
- the parser shouldn't crash in the absence of trailing new line at the end of its configuration file

This should fix #453