### PR TITLE
generate_rules.php: Don't whitelist files if the function name is actually a method of a class

### DIFF
--- a/scripts/generate_rules.php
+++ b/scripts/generate_rules.php
@@ -40,6 +40,8 @@ foreach($objects as $name => $object){
 		$hash = '.hash("' . hash('sha256', $file_content) . '")';
 	}
 
+	$prev_token = null;
+
 	foreach(token_get_all($file_content) as $token) {
 		if (!is_array($token)) {
 			continue;
@@ -49,9 +51,13 @@ foreach($objects as $name => $object){
 			$token[1] = substr($token[1], 1);
 		}
 
-		if (in_array($token[1], $functions_blacklist, true)) {
+		$prev_token_str = $prev_token[1] ?? null;
+
+		if (in_array($token[1], $functions_blacklist, true) && $prev_token_str !== '->' && $prev_token_str !== '::') {
 			$output[] = 'sp.disable_function.function("' . $token[1] . '").filename("' . $name . '")' . $hash . '.allow();' . "\n";
 		}
+
+		$prev_token = $token;
 	}
 }
 foreach($functions_blacklist as $fun) {


### PR DESCRIPTION
If the files are using code like `$db->exec('INSERT INTO...');` or `MyClass::assert(true === true);` these will be marked as whitelisted by the script, but they should not be, as they're not actually running the dangerous functions.