### PR TITLE
fix: Build PHP with Debug mode

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -40,4 +40,3 @@ jobs:
             https://scan.coverity.com/builds?project=jvoisin/snuffleupagus
         env:
           TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
-

--- a/src/sp_wrapper.c
+++ b/src/sp_wrapper.c
@@ -100,7 +100,7 @@ static php_stream * sp_php_stream_url_wrap_php(php_stream_wrapper *wrapper,
 
   extern PHPAPI const php_stream_wrapper php_stream_php_wrapper;
 
-  return php_stream_php_wrapper.wops->stream_opener(wrapper, path, mode, options, opened_path, context STREAMS_DC);
+  return php_stream_php_wrapper.wops->stream_opener(wrapper, path, mode, options, opened_path, context STREAMS_CC);
 }
 
 /*


### PR DESCRIPTION
With the introduction of #490 
Extension build with `--enable-debug` is failing because of `STREAMS_DC` expansion in debug mode:
https://github.com/php/php-src/blob/a22eb4d3e55b9edf835f58ceab5a3e50012fc1b1/main/php_streams.h#L36-L56

I replaced it with `STREAMS_CC` instead. It works well, and the production builds are unaffected because `STREAMS_CC` is defined as empty.

I cannot set a reproducer for the CI, as the official Docker images for PHP don't have a debug one for now.

Original build error:
```
In file included from /usr/include/php/main/php.h:415,
                 from /usr/include/php/main/SAPI.h:20,
                 from /home/ptondereau/Code/snuffleupagus/src/php_snuffleupagus.h:37,
                 from /home/ptondereau/Code/snuffleupagus/src/sp_wrapper.c:1:
/home/ptondereau/Code/snuffleupagus/src/sp_wrapper.c: In function ‘sp_php_stream_url_wrap_php’:
/usr/include/php/main/php_streams.h:39:41: error: expected expression before ‘int’
   39 | # define STREAMS_D                      int __php_stream_call_depth ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC
      |                                         ^~~
/usr/include/php/main/php_streams.h:45:35: note: in expansion of macro ‘STREAMS_D’
   45 | # define STREAMS_DC             , STREAMS_D
      |                                   ^~~~~~~~~
/home/ptondereau/Code/snuffleupagus/src/sp_wrapper.c:104:104: note: in expansion of macro ‘STREAMS_DC’
  104 |   return php_stream_php_wrapper.wops->stream_opener(wrapper, path, mode, options, opened_path, context STREAMS_DC);
      |                                                                                                        ^~~~~~~~~~
/home/ptondereau/Code/snuffleupagus/src/sp_wrapper.c:104:10: error: too few arguments to function ‘((const php_stream_wrapper_ops *)php_stream_php_wrapper.wops)->stream_opener’
  104 |   return php_stream_php_wrapper.wops->stream_opener(wrapper, path, mode, options, opened_path, context STREAMS_DC);
      |          ^~~~~~~~~~~~~~~~~~~~~~
/home/ptondereau/Code/snuffleupagus/src/sp_wrapper.c:108:1: warning: control reaches end of non-void function [-Wreturn-type]
  108 | }
      | ^

```