### PR TITLE
PHP 8.5 - Fix php_setcookie disabling urlencoding

### DIFF
--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -218,7 +218,7 @@ PHP_FUNCTION(sp_setcookie) {
     partitioned = false;
   }
   if (php_setcookie(name, (value_enc ? value_enc : value), expires, path,
-                    domain, secure, httponly, samesite, partitioned, false) == SUCCESS) {
+                    domain, secure, httponly, samesite, partitioned, 1) == SUCCESS) {
 #endif
     RETVAL_TRUE;
   } else {


### PR DESCRIPTION
Tried running Snuffleupagus ( ea53f247a64f0702e983c0ce98ba7655ca7762a8 ) on PHP 8.5.0 and got hit by this error:
```
PHP Fatal error:  Uncaught ValueError: setcookie(): Argument #2 ($value) cannot contain ",", ";", " ", "\t", "\r", "\n", "\013", or "\014" in /www/site/public/test.php:3
Stack trace:
#0 /www/site/public/test.php(3): setcookie()
#1 {main}
  thrown in /www/site/public/test.php on line 3
```

Code:
```php
setcookie( 'wordpress_test_cookie', 'WP Cookie check', 0, '/', '', TRUE, TRUE );
```

Seems like the PHP 8.5 php_setcookie call had set url_encode to false which should only happen for `setrawcookie()`; this was causing the error to throw.

https://github.com/php/php-src/blob/685e99655ae97c667950f7f7d176985958718f56/ext/standard/head.c#L97
```c
	if (!url_encode && value &&
			strpbrk(ZSTR_VAL(value), ",; \t\r\n\013\014") != NULL) { /* man isspace for \013 and \014 */
		zend_argument_value_error(2, "cannot contain " ILLEGAL_COOKIE_CHARACTER);
		return FAILURE;
	}
```