### PR TITLE
Fix possible arbitrary code execution on misconfigured deployments

### DIFF
--- a/scripts/upload_validation.php
+++ b/scripts/upload_validation.php
@@ -16,6 +16,7 @@ function check($filename) {
 		"-d", "vld.col_sep=@",
 		"-d", "log_errors=0",
 		"-d", "error_log=/dev/null",
+            	"-B", "if (!extension_loaded('vld')) die('no vld');",
 		escapeshellarg($filename),
 		'2>&1',
 		];

--- a/scripts/upload_validation.py
+++ b/scripts/upload_validation.py
@@ -15,6 +15,7 @@ def check(filename):
             "-d", "vld.col_sep=@",
             "-d", "log_errors=0",
             "-d", "error_log=/dev/null",
+            "-B", "if (!extension_loaded('vld')) die('no vld');",
             filename],
             stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
When `upload_validation` is enabled, and when VLD isn't installed, an attacker able to upload files is able to have their content executed.

Reported-By: swapgs